### PR TITLE
Modificando los esquemas de ubuntu mate forzar tema predeterminado

### DIFF
--- a/30_ucr-mate-settings.gschema.override
+++ b/30_ucr-mate-settings.gschema.override
@@ -2,21 +2,67 @@
 gtk-theme='Arc-Darker'
 icon-theme='Numix-Circle'
 
+
+
+[org.gnome.desktop.wm.preferences]
+theme='Arc-Darker'
+
+[org.mate.desktop.interface]
+gtk-theme='Arc-Darker'
+icon-theme='Numix-Circle'
+
+[org.mate.interface]
+icon-theme='Numix-Circle'
+gtk-theme='Arc-Darker'
+gtk-decoration-layout='menu:minimize,maximize,close'
+font-name='Ubuntu 11'
+document-font-name='Ubuntu 11'
+monospace-font-name='Ubuntu Mono 13'
+
 [org.gnome.desktop.wm.preferences]
 theme='Arc-Darker'
 
 [org.mate.background]
 picture-filename='/usr/share/backgrounds/ucr/ubuntu-16.04-ucr-background.jpg'
 
-[org.mate.interface]
-icon-theme='Numix-Circle'
-gtk-theme='Arc-Darker'
-
-[org.mate.Marco.general]
+[org.mate.marco.general]
 theme='Arc-Darker'
 
 [org.mate.pluma]
 color-scheme='Classic'
-display-line-numbers=false
+display-line-numbers=true
 display-right-margin=false
 highlight-current-line=false
+
+[org.mate.applications-at-mobility]
+exec='onboard'
+
+[org.mate.applications-at-visual]
+exec='orca'
+
+[org.mate.applications-office.calendar]
+exec='thunderbird'
+
+[org.mate.applications-office.tasks]
+exec='thunderbird'
+
+[org.mate.disk-usage-analyzer.ui]
+statusbar-visible=true
+
+[org.mate.font-rendering]
+antialiasing = 'rgba'
+hinting = 'slight'
+
+[org.mate.panel]
+default-layout='ubuntu-mate'
+show-program-list=true
+
+[org.mate.peripherals-mouse]
+cursor-theme='DMZ-White'
+
+[org.mate.stickynotes]
+default-font='Ubuntu 10'
+
+[org.mate.peripherals-touchpad]
+disable-while-typing=true
+tap-to-click=true

--- a/ubuntu-16.04-ucr-config.sh
+++ b/ubuntu-16.04-ucr-config.sh
@@ -346,8 +346,10 @@ then
 
   # Copia esquema que sobrescribe configuracion de MATE y lo compila
   sudo cp "$BASEDIR"/30_ucr-mate-settings.gschema.override /usr/share/glib-2.0/schemas/
+  sudo cp "$BASEDIR"/ubuntu-mate.gschema.override /usr/share/glib-2.0/schemas/
+  sudo rm /usr/share/glib-2.0/schemas/mate-ubuntu.gschema.override
   sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
-
+  
   # Configura pantalla de autenticacion
   sudo sh -c 'echo "[greeter]
 background = /usr/share/backgrounds/ucr/ubuntu-16.04-ucr-background.jpg

--- a/ubuntu-mate.gschema.override
+++ b/ubuntu-mate.gschema.override
@@ -1,0 +1,130 @@
+[com.ubuntu.update-manager]
+show-details=true
+show-versions=true
+
+[net.launchpad.plank.dock.settings]
+dock-items=['desktop.dockitem','clock.dockitem','firefox.dockitem','matecc.dockitem']
+hide-mode='window-dodge'
+show-dock-item=true
+theme='Ubuntu-MATE'
+
+[org.gnome.crypto.pgp]
+keyservers=['hkp://keyserver.ubuntu.com:11371', 'hkp://pool.sks-keyservers.net', 'ldap://keyserver.pgp.com']
+
+[org.gnome.desktop.interface]
+cursor-theme='DMZ-White'
+document-font-name='Ubuntu 11'
+font-name='Ubuntu 11'
+monospace-font-name='Ubuntu Mono 13'
+
+[org.gnome.desktop.wm.preferences]
+button-layout='menu:minimize,maximize,close'
+theme='Ambiant-MATE'
+titlebar-font='Ubuntu Bold 11'
+
+[org.gnome.rhythmbox.encoding-settings]
+media-type-presets={'audio/x-vorbis':'Ubuntu', 'audio/mpeg':'Ubuntu'}
+
+[org.gnome.rhythmbox.rhythmdb]
+monitor-library=true
+
+[org.gnome.rhythmbox.plugins]
+active-plugins=['artsearch', 'audiocd','audioscrobbler','cd-recorder','daap','dbus-media-server','generic-player','ipod','iradio','mmkeys','mpris','mtpdevice','notification','power-manager']
+
+[org.gnome.Charmap]
+font='Ubuntu 22'
+
+[org.gtk.Settings.FileChooser]
+show-hidden=false
+show-size-column=true
+sort-directories-first=true
+
+[org.mate.caja.desktop]
+font='Ubuntu 11'
+computer-icon-visible=false
+home-icon-visible=true
+trash-icon-visible=false
+
+[org.mate.control-center.appearance]
+more-backgrounds-url='https://ubuntu-mate.community/c/multimedia/artwork'
+
+[org.mate.dictionary]
+print-font='Ubuntu 12'
+
+[org.mate.media-handling]
+autorun-x-content-start-app=['x-content/software','x-content/video-bluray.xml','x-content/video-dvd.xml', 'x-content/video-hddvd.xml','x-content/video-svcd.xml','x-content/video-vcd.xml']
+
+[org.mate.Marco.general]
+center-new-windows=false
+compositing-manager=true
+side-by-side-tiling=true
+theme='Ambiant-MATE'
+titlebar-font='Ubuntu Medium 11'
+
+[org.mate.Marco.global-keybindings]
+run-command-terminal='<Control><Alt>t'
+switch-panels='disabled'
+switch-windows='<Alt>Tab'
+switch-windows-all='<Control><Alt>Tab'
+switch-windows-all-backward='<Control><Alt><Shift>Tab'
+switch-windows-backward='<Alt><Shift>Tab'
+
+[org.mate.Marco.window-keybindings]
+move-to-center='<Control><Alt>KP_Begin'
+move-to-corner-ne='<Control><Alt>KP_Page_Up'
+move-to-corner-nw='<Control><Alt>KP_Home'
+move-to-corner-se='<Control><Alt>KP_Page_Down'
+move-to-corner-sw='<Control><Alt>KP_End'
+move-to-side-n='<Control><Alt>KP_Up'
+move-to-side-s='<Control><Alt>KP_Down'
+tile-to-side-e='<Control><Alt>KP_Right'
+tile-to-side-w='<Control><Alt>KP_Left'
+
+[org.mate.NotificationDaemon]
+theme='slider'
+
+[org.mate.maximus]
+no-maximize=true
+undecorate=false
+
+
+[org.mate.pluma]
+color-scheme='Ambiant-MATE'
+display-line-numbers=true
+display-right-margin=false
+highlight-current-line=true
+editor-font='Ubuntu Mono 13'
+print-font-body-pango='Ubuntu Mono 9'
+print-font-header-pango='Ubuntu 11'
+print-font-numbers-pango='Ubuntu 8'
+
+[org.mate.screensaver]
+lock-delay=1
+mode='single'
+themes=['screensavers-footlogo-floaters']
+
+[org.mate.sound]
+theme-name='ubuntu'
+event-sounds=true
+input-feedback-sounds=true
+
+[org.mate.session]
+idle-delay=30
+
+[org.mate.SettingsDaemon.plugins.media-keys]
+magnifier='<Alt><Mod4>m'
+screenreader='<Alt><Mod4>s'
+on-screen-keyboard='<Alt><Mod4>k'
+
+
+
+[org.mate.system-monitor]
+show-tree=true
+solaris-mode=true
+
+[org.mate.terminal.profile]
+allow-bold=false
+use-system-font=true
+
+[org.yorba.shotwell.printing]
+titles-font='Ubuntu Bold 12'


### PR DESCRIPTION
El siguiente PR corrige agrega el tema por defecto a Mate.
Actualmente el sistema sobre escribe las propiedades, pero la personalización de ubuntu (ubuntu-mate) también lo hace, al asignarse las propiedades en orden de carga el script 30_ucr-mate-settings.gschema.override se corre antes que ubuntu-mate.gschema.override provocando que se sobreescriba el tema por defecto.
Además se elimina el archivo mate-ubuntu.gschema.override pues está contenido en los otros dos.
Ante esto en este PR se agrega ubuntu-mate.gschema.override con algunas variaciones, principalmente migración de propiedades a  30_ucr-mate-settings.gschema.override.
El conjunto de ambas permite que el livecd generado ya tenga por defecto el tema en Mate.
